### PR TITLE
Fix correlation so it doesn't add the headers if they already exist

### DIFF
--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/ServiceRemotingLoggingStrings.cs
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/ServiceRemotingLoggingStrings.cs
@@ -2,8 +2,8 @@
 {
     internal static class ServiceRemotingLoggingStrings
     {
-        public const string ParentIdHeaderName = "ParentId";
-        public const string CorrelationContextHeaderName = "CorrelationContext";
+        public const string ParentIdHeaderName = "Microsoft.ApplicationInsights.ServiceFabric.ParentId";
+        public const string CorrelationContextHeaderName = "Microsoft.ApplicationInsights.ServiceFabric.CorrelationContext";
         public const string ServiceRemotingTypeName = "ServiceFabricServiceRemoting";
     }
 }

--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/ServiceRemotingMessageHeadersExtensions.cs
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/ServiceRemotingMessageHeadersExtensions.cs
@@ -58,6 +58,11 @@
             }
         }
 
+        public static bool ContainsHeader(this ServiceRemotingMessageHeaders messageHeaders, string headerName)
+        {
+            return messageHeaders.TryGetHeaderValue(headerName, out byte[] headerValueBytes);
+        }
+
         public static bool TryGetHeaderValue(this ServiceRemotingMessageHeaders messageHeaders, string headerName, out string headerValue)
         {
             headerValue = null;


### PR DESCRIPTION
Change the header names so they don't collide with user defined ones, if any.
Update the copy of nuget to v4.3