### PR TITLE
New CodePackageVersionTelemetryInitializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ The Nuget package enables correlation of traces produced by Service Fabric servi
         };
     }
     ```
+### Enrich telemetry with Component Version
+In order to have telemetry enriched with component version based on the code package version of the Service Fabric Reliable Service, add the following xml snippet to the ```<TelemetryInitializers>``` section:
+
+```<Add Type="Microsoft.ApplicationInsights.ServiceFabric.CodePackageVersionTelemetryInitializer, Microsoft.AI.ServiceFabric.Native"/>```
+
+Adding component version to telemetry items makes it possible to track telemetry across different versions of running services.
 
 ## Customizing Context:
 < to be added >

--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/ApplicationInsights.ServiceFabric.Native.csproj
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/ApplicationInsights.ServiceFabric.Native.csproj
@@ -89,6 +89,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CodePackageVersionTelemetryInitializer.cs" />
     <Compile Include="CorrelatingRemotingMessageHandler.cs" />
     <Compile Include="CorrelatingActorProxyFactory.cs" />
     <Compile Include="CorrelatingServiceProxyFactory.cs" />

--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/CodePackageVersionTelemetryInitializer.cs
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/CodePackageVersionTelemetryInitializer.cs
@@ -11,6 +11,11 @@
     public class CodePackageVersionTelemetryInitializer : ITelemetryInitializer
     {
         /// <summary>
+        /// The code package version for this component.
+        /// </summary>
+        private string codePackageVersion;
+
+        /// <summary>
         /// Initializes component version of the telemetry item with the code package version from the Service Fabric runtime activation context.
         /// </summary>
         /// <param name="telemetry">The telemetry context to initialize.</param>
@@ -23,8 +28,13 @@
 
             if (telemetry.Context?.Component != null && string.IsNullOrEmpty(telemetry.Context.Component.Version))
             {
-                var activationContext = FabricRuntime.GetActivationContext();
-                telemetry.Context.Component.Version = activationContext.CodePackageVersion;
+                if (string.IsNullOrEmpty(codePackageVersion))
+                {
+                    var activationContext = FabricRuntime.GetActivationContext();
+                    codePackageVersion = activationContext.CodePackageVersion;
+                }
+
+                telemetry.Context.Component.Version = codePackageVersion;
             }
         }
     }

--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/CodePackageVersionTelemetryInitializer.cs
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/CodePackageVersionTelemetryInitializer.cs
@@ -1,0 +1,31 @@
+﻿namespace Microsoft.ApplicationInsights.ServiceFabric
+{
+    using System;
+    using System.Fabric;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// A telemetry initializer that will set component version based on the code package version of a Service Fabric Reliable Service.
+    /// </summary>
+    public class CodePackageVersionTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Initializes component version of the telemetry item with the code package version from the Service Fabric runtime activation context.
+        /// </summary>
+        /// <param name="telemetry">The telemetry context to initialize.</param>
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry == null)
+            {
+                throw new ArgumentNullException(nameof(telemetry));
+            }
+
+            if (telemetry.Context?.Component != null && string.IsNullOrEmpty(telemetry.Context.Component.Version))
+            {
+                var activationContext = FabricRuntime.GetActivationContext();
+                telemetry.Context.Component.Version = activationContext.CodePackageVersion;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added new telemetry initializer that sets component version of a telemetry item based on the code package version of a reliable service, if it has not already been set by other means.

Updated README.md adding description of how to use CodePackageVersionTelemetryInitializer.

Implementation of #41 

Code inspired by [BuildInfoConfigComponentVersionTelemetryInitializer](https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/75373e57dcf8d646c54ee188461c373f2cc98939/Src/WindowsServer/WindowsServer.Shared/BuildInfoConfigComponentVersionTelemetryInitializer.cs)

