### PR TITLE
Fix issue #73. FabricTelemetryInitializer exists in multiple assemblies.

### DIFF
--- a/src/ApplicationInsights.ServiceFabric.Native/NetStandard/ApplicationInsights.ServiceFabric.Native.NetStandard.csproj
+++ b/src/ApplicationInsights.ServiceFabric.Native/NetStandard/ApplicationInsights.ServiceFabric.Native.NetStandard.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\ApplicationInsights.ServiceFabric\Shared\ApplicationInsights.ServiceFabric.Shared.projitems" Label="Shared" />
   <Import Project="..\..\ApplicationInsights.ServiceFabric.Native.Shared\ApplicationInsights.ServiceFabric.Native.Shared.projitems" Label="Shared" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildThisFileDirectory)\..', 'Product.props'))\Product.props" />
   <PropertyGroup>
@@ -32,5 +31,9 @@
     
     <!-- We should keep an eye for this to become public. This dependency provides a .net core ported version of MemoryCache. The port has happened recently. -->
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0-preview1-25914-04" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ApplicationInsights.ServiceFabric\NetStandard\ApplicationInsights.ServiceFabric.NetStandard.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ApplicationInsights.ServiceFabric.Native/NetStandard/Microsoft.AI.ServiceFabric.Native.xml
+++ b/src/ApplicationInsights.ServiceFabric.Native/NetStandard/Microsoft.AI.ServiceFabric.Native.xml
@@ -4,51 +4,6 @@
         <name>Microsoft.AI.ServiceFabric.Native</name>
     </assembly>
     <members>
-        <member name="T:Microsoft.ApplicationInsights.ServiceFabric.CallContext">
-            <summary>
-            .Net core does not have a CallContext implementation. So we are wrapping async local and providing an alternative implementation.
-            </summary>
-        </member>
-        <member name="M:Microsoft.ApplicationInsights.ServiceFabric.CallContext.LogicalSetData(System.String,System.Object)">
-            <summary>
-            Stores the given object as an async local object in our collection.
-            </summary>
-            <param name="name">The call context name.</param>
-            <param name="data">The object to store.</param>
-        </member>
-        <member name="M:Microsoft.ApplicationInsights.ServiceFabric.CallContext.LogicalGetData(System.String)">
-            <summary>
-            Retrieves the object stored against the given name.
-            </summary>
-            <param name="name">The name against which item was stored.</param>
-            <returns>The object retrieved.</returns>
-        </member>
-        <member name="T:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer">
-            <summary>
-            Telemetry initializer for service fabric. Adds service fabric specific context to outgoing telemetry.
-            </summary>
-        </member>
-        <member name="P:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer.ApplicableServiceContext">
-            <summary>
-            There are a few ways the context could be provided. This property makes it easy for the rest of the implemenatation to ignore all those cases. 
-            </summary>
-        </member>
-        <member name="M:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer.#ctor">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer"/> class.
-            </summary>
-        </member>
-        <member name="M:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer.#ctor(System.Collections.Generic.Dictionary{System.String,System.String})">
-            <summary>
-            Initializes a new instance of the <see cref="T:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer"/> class.
-            </summary>
-        </member>
-        <member name="M:Microsoft.ApplicationInsights.ServiceFabric.FabricTelemetryInitializer.Initialize(Microsoft.ApplicationInsights.Channel.ITelemetry)">
-            <summary>
-            Adds service fabric context fields on the given telemetry object.
-            </summary>
-            <param name="telemetry">The telemetry item being sent through the AI sdk.</param>
-        </member>
         <member name="F:Microsoft.ApplicationInsights.ServiceFabric.Module.CacheBasedOperationHolder`1.memoryCache">
             <summary>
             The memory cache instance used to hold items. MemoryCache.Default is not used as it is shared 

--- a/src/ApplicationInsights.ServiceFabric.sln
+++ b/src/ApplicationInsights.ServiceFabric.sln
@@ -20,6 +20,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationInsights.ServiceFabric.Native.NuGet", "ApplicationInsights.ServiceFabric.Native\NuGet\ApplicationInsights.ServiceFabric.Native.NuGet.csproj", "{820D2E4F-4D2F-463F-A1B3-778526936820}"
 	ProjectSection(ProjectDependencies) = postProject
 		{D58E6722-7F75-43F2-B04A-30F5A571ED28} = {D58E6722-7F75-43F2-B04A-30F5A571ED28}
+		{AE9702EC-D77E-49E7-8837-C00EAFA07397} = {AE9702EC-D77E-49E7-8837-C00EAFA07397}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationInsights.ServiceFabric.Native.NetStandard", "ApplicationInsights.ServiceFabric.Native\NetStandard\ApplicationInsights.ServiceFabric.Native.NetStandard.csproj", "{AE9702EC-D77E-49E7-8837-C00EAFA07397}"

--- a/src/ApplicationInsights.ServiceFabric/Shared/CallContext.cs
+++ b/src/ApplicationInsights.ServiceFabric/Shared/CallContext.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ApplicationInsights.ServiceFabric
     /// <summary>
     /// .Net core does not have a CallContext implementation. So we are wrapping async local and providing an alternative implementation.
     /// </summary>
-    internal static class CallContext
+    public static class CallContext
     {
         private static ConcurrentDictionary<string, AsyncLocal<object>> _collection = new ConcurrentDictionary<string, AsyncLocal<object>>();
 


### PR DESCRIPTION
This issue is caused by referencing the shared project in both assemblies.
Reorganize the project so the TelemetryInitailizer only exist in on dll.