### PR TITLE
change to set the RoleName with service name

### DIFF
--- a/src/ApplicationInsights.ServiceFabric/Shared/FabricTelemetryInitializer.cs
+++ b/src/ApplicationInsights.ServiceFabric/Shared/FabricTelemetryInitializer.cs
@@ -90,6 +90,11 @@
                 // And for reliable services, when service context is neither provided directly nor through call context
                 if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
                 {
+                    telemetry.Context.Cloud.RoleName = Environment.GetEnvironmentVariable(KnownEnvironmentVariableName.ServiceName);
+                }
+                
+                if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleName))
+                {
                     telemetry.Context.Cloud.RoleName = Environment.GetEnvironmentVariable(KnownEnvironmentVariableName.ServicePackageName);
                 }
 
@@ -129,6 +134,7 @@
 
         private class KnownEnvironmentVariableName
         {
+            public const string ServiceName = "Fabric_ServiceName";
             public const string ServicePackageName = "Fabric_ServicePackageName";
             public const string ServicePackageInstanceId = "Fabric_ServicePackageInstanceId";
             public const string ServicePackageActivatonId = "Fabric_ServicePackageActivationId";


### PR DESCRIPTION
Change fallback to set RoleName with service name from environment variables to be more consistent with the role name set from the service context.