### PR TITLE
Updated to service fabric 3.3.664 and added implementation of CreateNonIServiceProxy

### DIFF
--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/ApplicationInsights.ServiceFabric.Native.csproj
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/ApplicationInsights.ServiceFabric.Native.csproj
@@ -30,43 +30,43 @@
       <HintPath>..\..\..\..\packages\Microsoft.ApplicationInsights.2.3.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Actors, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.2.162\lib\net45\Microsoft.ServiceFabric.Actors.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.3.664\lib\net45\Microsoft.ServiceFabric.Actors.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.3.2.162\lib\net45\Microsoft.ServiceFabric.Data.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.3.3.664\lib\net45\Microsoft.ServiceFabric.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ServiceFabric.Data.Extensions, Version=1.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.Extensions.1.4.162\lib\net45\Microsoft.ServiceFabric.Data.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.ServiceFabric.Data.Extensions, Version=1.4.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.Extensions.1.4.664\lib\net45\Microsoft.ServiceFabric.Data.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Data.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.Interfaces.3.2.162\lib\net45\Microsoft.ServiceFabric.Data.Interfaces.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.Interfaces.3.3.664\lib\net45\Microsoft.ServiceFabric.Data.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Diagnostics, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Diagnostics.Internal.3.2.162\lib\net45\Microsoft.ServiceFabric.Diagnostics.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Diagnostics.Internal.3.3.664\lib\net45\Microsoft.ServiceFabric.Diagnostics.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.FabricTransport, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.FabricTransport.Internal.3.2.162\lib\net45\Microsoft.ServiceFabric.FabricTransport.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.FabricTransport.Internal.3.3.664\lib\net45\Microsoft.ServiceFabric.FabricTransport.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.FabricTransport.V2, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.FabricTransport.Internal.3.2.162\lib\net45\Microsoft.ServiceFabric.FabricTransport.V2.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.FabricTransport.Internal.3.3.664\lib\net45\Microsoft.ServiceFabric.FabricTransport.V2.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Internal, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\Microsoft.ServiceFabric.Internal.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\Microsoft.ServiceFabric.Internal.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Internal.Strings, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\Microsoft.ServiceFabric.Internal.Strings.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\Microsoft.ServiceFabric.Internal.Strings.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Preview, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\Microsoft.ServiceFabric.Preview.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\Microsoft.ServiceFabric.Preview.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.ReliableCollection.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.Extensions.1.4.162\lib\net45\Microsoft.ServiceFabric.ReliableCollection.Interop.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Data.Extensions.1.4.664\lib\net45\Microsoft.ServiceFabric.ReliableCollection.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Services, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Services.3.2.162\lib\net45\Microsoft.ServiceFabric.Services.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Services.3.3.664\lib\net45\Microsoft.ServiceFabric.Services.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceFabric.Services.Remoting, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Services.Remoting.3.2.162\lib\net45\Microsoft.ServiceFabric.Services.Remoting.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.Services.Remoting.3.3.664\lib\net45\Microsoft.ServiceFabric.Services.Remoting.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -74,16 +74,16 @@
       <HintPath>..\..\..\..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Fabric, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\System.Fabric.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\System.Fabric.dll</HintPath>
     </Reference>
     <Reference Include="System.Fabric.Management.ServiceModel, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\System.Fabric.Management.ServiceModel.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\System.Fabric.Management.ServiceModel.dll</HintPath>
     </Reference>
     <Reference Include="System.Fabric.Management.ServiceModel.XmlSerializers, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\System.Fabric.Management.ServiceModel.XmlSerializers.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\System.Fabric.Management.ServiceModel.XmlSerializers.dll</HintPath>
     </Reference>
     <Reference Include="System.Fabric.Strings, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=AMD64">
-      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.3.162\lib\net45\System.Fabric.Strings.dll</HintPath>
+      <HintPath>..\..\..\..\packages\Microsoft.ServiceFabric.6.4.664\lib\net45\System.Fabric.Strings.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
@@ -110,7 +110,9 @@
     <Compile Include="TaskExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ApplicationInsights.ServiceFabric\Net45\ApplicationInsights.ServiceFabric.Net45.csproj">
@@ -126,10 +128,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.2.162\build\net45\Microsoft.ServiceFabric.Actors.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.2.162\build\net45\Microsoft.ServiceFabric.Actors.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.3.664\build\net45\Microsoft.ServiceFabric.Actors.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.3.664\build\net45\Microsoft.ServiceFabric.Actors.targets'))" />
   </Target>
   <Import Project="..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
-  <Import Project="..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.2.162\build\net45\Microsoft.ServiceFabric.Actors.targets" Condition="Exists('..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.2.162\build\net45\Microsoft.ServiceFabric.Actors.targets')" />
+  <Import Project="..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.3.664\build\net45\Microsoft.ServiceFabric.Actors.targets" Condition="Exists('..\..\..\..\packages\Microsoft.ServiceFabric.Actors.3.3.664\build\net45\Microsoft.ServiceFabric.Actors.targets')" />
 </Project>

--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/CorrelatingServiceProxyFactory.cs
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/CorrelatingServiceProxyFactory.cs
@@ -61,5 +61,23 @@
             this.methodNameProvider.AddMethodsForProxyOrService(proxy.GetType().GetInterfaces(), typeof(IService));
             return proxy;
         }
+
+        /// <summary>
+        /// Creates a proxy to communicate to the specified service using the remoted interface TServiceInterface that 
+        /// the service implements.
+        /// <typeparam name="TServiceInterface">Interface that is being remoted</typeparam>
+        /// <param name="serviceUri">Uri of the Service.</param>
+        /// <param name="partitionKey">The Partition key that determines which service partition is responsible for handling requests from this service proxy</param>
+        /// <param name="targetReplicaSelector">Determines which replica or instance of the service partition the client should connect to.</param>
+        /// <param name="listenerName">This parameter is Optional if the service has a single communication listener. The endpoints from the service
+        /// are of the form {"Endpoints":{"Listener1":"Endpoint1","Listener2":"Endpoint2" ...}}. When the service exposes multiple endpoints, this parameter
+        /// identifies which of those endpoints to use for the remoting communication.
+        /// </param>
+        /// <returns>The proxy that implement the interface that is being remoted. The returned object also implement <see cref="T:Microsoft.ServiceFabric.Services.Remoting.Client.IServiceProxy" /> interface.</returns>
+        /// </summary>
+        public TServiceInterface CreateNonIServiceProxy<TServiceInterface>(Uri serviceUri, ServicePartitionKey partitionKey = null, TargetReplicaSelector targetReplicaSelector = TargetReplicaSelector.Default, string listenerName = null)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/ApplicationInsights.ServiceFabric.Native/Net45/packages.config
+++ b/src/ApplicationInsights.ServiceFabric.Native/Net45/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.ServiceFabric" version="6.3.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Actors" version="3.2.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Data" version="3.2.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Data.Extensions" version="1.4.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Data.Interfaces" version="3.2.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Diagnostics.Internal" version="3.2.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.FabricTransport.Internal" version="3.2.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Services" version="3.2.162" targetFramework="net45" />
-  <package id="Microsoft.ServiceFabric.Services.Remoting" version="3.2.162" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric" version="6.4.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Actors" version="3.3.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Data" version="3.3.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Data.Extensions" version="1.4.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Data.Interfaces" version="3.3.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Diagnostics.Internal" version="3.3.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.FabricTransport.Internal" version="3.3.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Services" version="3.3.664" targetFramework="net45" />
+  <package id="Microsoft.ServiceFabric.Services.Remoting" version="3.3.664" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net45" />
 </packages>

--- a/src/ApplicationInsights.ServiceFabric.Native/NetStandard/ApplicationInsights.ServiceFabric.Native.NetStandard.csproj
+++ b/src/ApplicationInsights.ServiceFabric.Native/NetStandard/ApplicationInsights.ServiceFabric.Native.NetStandard.csproj
@@ -26,8 +26,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.2.162" />
-    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.2.162" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.664" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.3.664" />
     
     <!-- We should keep an eye for this to become public. This dependency provides a .net core ported version of MemoryCache. The port has happened recently. -->
     <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />


### PR DESCRIPTION
The changes to the interface on pull request https://github.com/microsoft/service-fabric-services-and-actors-dotnet/pull/131/ is not compatible. Updated nuget packages and implemented interface with a NotSupportedException.