### PR TITLE
Ref a newer version of Application Insights for Native .NetStandard

### DIFF
--- a/src/ApplicationInsights.ServiceFabric.Native/NetStandard/ApplicationInsights.ServiceFabric.Native.NetStandard.csproj
+++ b/src/ApplicationInsights.ServiceFabric.Native/NetStandard/ApplicationInsights.ServiceFabric.Native.NetStandard.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="MicroBuild.Core" Version="0.2.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="3.3.664" />
     <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="3.3.664" />
     


### PR DESCRIPTION
We're using this in a project, and we're getting various security warnings in Snyk related to dependencies included via `Microsoft.ApplicationInsights` 2.4.0. 

This change updates the reference version of Application Insights, and should hopefully mitigate a number of security issues.
